### PR TITLE
add subresponse_exception_handler in order to deal more sane with 401…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,6 @@ New:
 - Behavior shortname ``plone.layoutaware`` added.
   [jensens]
 
-
 Fixes:
 
 - A tile raising an 401 Unauthorized on traversal,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,14 @@ New:
 
 Fixes:
 
+- A tile raising an 401 Unauthorized on traversal,
+  results in a status rewriting to a 302 which results in 200 login form.
+  The whole login form page then is rendered as the tile contents.
+  This patch catches the 401 by providing a custom exception handler.
+  The 401 is catched and ignored. This is not pefect yet and need some work,
+  but it at least does not break design and intended behavior of tiles.
+  [jensens]
+
 - Test failure in Plone 5
   [jensens]
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -9,6 +9,15 @@ package-extras = [test]
 parts +=
     createcoverage
 
+extensions = mr.developer
+auto-checkout =
+    plone.subrequest
+    plone.tiles
+
+[sources]
+plone.tiles =      git git://github.com/plone/plone.tiles.git
+plone.subrequest = git git://github.com/plone/plone.subrequest.git
+
 [code-analysis]
 directory = plone
 flake8-ignore = E501,C901

--- a/plone/app/blocks/tests/esi.rst
+++ b/plone/app/blocks/tests/esi.rst
@@ -53,7 +53,8 @@ Let's first register a two very simple tiles. One uses ESI, one does not.
     ...     name=u'test.tile2',
     ...     title=u"Test tile 2",
     ...     description=u"A tile used for testing",
-    ...     add_permission="cmf.ManagePortal")
+    ...     add_permission="cmf.ManagePortal",
+    ...     view_permission="zope2.View")
 
     >>> class SimpleESITile(ESITile):
     ...     __name__ = 'test.tile3' # normally set by ZCML handler
@@ -75,7 +76,8 @@ Let's first register a two very simple tiles. One uses ESI, one does not.
     ...     name=u'test.tile3',
     ...     title=u"Test tile 3",
     ...     description=u"A tile used for testing",
-    ...     add_permission="cmf.ManagePortal")
+    ...     add_permission="cmf.ManagePortal",
+    ...     view_permission="zope2.View")
 
 Register these in the same way that the ZCML handlers would, more or less.
 

--- a/plone/app/blocks/tests/rendering.rst
+++ b/plone/app/blocks/tests/rendering.rst
@@ -273,13 +273,15 @@ We register these views and tiles in the same way the ZCML handlers for ``<brows
     ...     title=u"Test tile",
     ...     description=u"A tile used for testing",
     ...     add_permission="cmf.ManagePortal",
+    ...     view_permission="zope2.View",
     ...     schema=ITestTile)
 
     >>> testTileTypeNoBody = TileType(
     ...     name=u'test.tile_nobody',
     ...     title=u"Test tile using only a header",
     ...     description=u"Another tile used for testing",
-    ...     add_permission="cmf.ManagePortal")
+    ...     add_permission="cmf.ManagePortal",
+    ...     view_permission="zope2.View")
 
     >>> protectClass(Page, 'zope2.View')
     >>> protectClass(TestTile, 'zope2.View')

--- a/plone/app/blocks/tiles.py
+++ b/plone/app/blocks/tiles.py
@@ -9,8 +9,14 @@ from plone.tiles.interfaces import ESI_HEADER
 from plone.tiles.interfaces import ESI_HEADER_KEY
 from urlparse import urljoin
 from zExceptions import NotFound
+from zExceptions import Unauthorized
 from zope.component import queryUtility
 from zope.i18n import translate
+
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def errorTile(request):
@@ -47,6 +53,11 @@ def renderTiles(request, tree):
         except RuntimeError:
             tileTree = None
         except NotFound:
+            logger.warn(
+                'NotFound while trying to render tile: {0}'.format(
+                    tileHref
+                )
+            )
             continue
         if tileTree is not None:
             tileRoot = tileTree.getroot()


### PR DESCRIPTION
… catched by plones redirection logic.

A tile raising an 401 Unauthorized on traversal, results in a status rewriting to a 302 which results in 200 login form. The **whole** login form page then is rendered as the tile contents.

This patch catches the 401 by providing a custom exception handler.

The 401 is catched and ignored. This is not pefect yet and need some work,  but it at least does not break design and intended behavior of tiles.