### PR TITLE
Move 'content' to 'customLayout'; Add 'content' back as tile data storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python: 2.7
 sudo: false
 env:
-  - PLONE_VERSION=4.x
   - PLONE_VERSION=5.x
 cache:
   pip: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Incompatibilities:
 - Removed pluggable grid framework
   [agitator]
 
+- Moved ``ILayoutAware.content`` to ``ILayoutAware.customLayout``.
+  Added ``ILayoutAware.content`` as layout independent, but layout
+  like, tile data storage
+  [datakurre]
+
 - Moved functions ``getDefaultAjaxLayout``, ``getDefaultSiteLayout``, ``getLayout`` and ``getLayoutAwareSiteLayout`` to ``.layoutbehavior`` in order to avoid circular imports
   (all deprecated now, see section New).
   [jensens]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 Incompatibilities:
 
+- Remove official Plone 4 support
+  [datakurre]
+
 - Removed pluggable grid framework
   [agitator]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Incompatibilities:
 - Removed pluggable grid framework
   [agitator]
 
-- Moved ``ILayoutAware.content`` to ``ILayoutAware.customLayout``.
+- Moved ``ILayoutAware.content`` to ``ILayoutAware.customContentLayout``.
   Added ``ILayoutAware.content`` as layout independent, but layout
   like, tile data storage
   [datakurre]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -15,7 +15,7 @@ auto-checkout =
     plone.tiles
 
 [sources]
-plone.tiles =      git git://github.com/plone/plone.tiles.git
+plone.tiles =      git git://github.com/plone/plone.tiles.git branch=datakurre-tile-data-storage
 plone.subrequest = git git://github.com/plone/plone.subrequest.git
 
 [code-analysis]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -17,7 +17,7 @@ auto-checkout =
 
 [sources]
 plone.jsonserializer = git git://github.com/plone/plone.jsonserializer.git
-plone.tiles =          git git://github.com/plone/plone.tiles.git branch=datakurre-tile-data-storage
+plone.tiles =          git git://github.com/plone/plone.tiles.git branch=master
 plone.subrequest =     git git://github.com/plone/plone.subrequest.git
 
 [code-analysis]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -15,8 +15,9 @@ auto-checkout =
     plone.tiles
 
 [sources]
-plone.tiles =      git git://github.com/plone/plone.tiles.git branch=datakurre-tile-data-storage
-plone.subrequest = git git://github.com/plone/plone.subrequest.git
+plone.jsonserializer = git git://github.com/plone/plone.jsonserializer.git
+plone.tiles =          git git://github.com/plone/plone.tiles.git branch=datakurre-tile-data-storage
+plone.subrequest =     git git://github.com/plone/plone.subrequest.git
 
 [code-analysis]
 directory = plone

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -11,6 +11,7 @@ parts +=
 
 extensions = mr.developer
 auto-checkout =
+    plone.jsonserializer
     plone.subrequest
     plone.tiles
 

--- a/plone/app/blocks/configure.zcml
+++ b/plone/app/blocks/configure.zcml
@@ -14,6 +14,7 @@
     <include package="plone.tiles" />
     <include package="plone.subrequest" />
     <include package="plone.transformchain" />
+    <include package="plone.jsonserializer" />
 
     <include package="plone.app.registry" />
 

--- a/plone/app/blocks/configure.zcml
+++ b/plone/app/blocks/configure.zcml
@@ -67,9 +67,10 @@
     <adapter
         for=".layoutbehavior.ILayoutBehaviorAdaptable
              * plone.tiles.interfaces.IPersistentTile"
-        factory="plone.tiles.data.defaultTileDataStorage"
+        factory="plone.tiles.data.defaultPersistentTileDataStorage"
         />
     <adapter
+        name="plone.app.blocks.layoutbehavior"
         factory=".drafting.LayoutAwareDataStorageSyncher"
         zcml:condition="installed plone.app.drafts"
         />

--- a/plone/app/blocks/configure.zcml
+++ b/plone/app/blocks/configure.zcml
@@ -60,8 +60,26 @@
         marker=".layoutbehavior.ILayoutBehaviorAdaptable"
         factory=".layoutbehavior.LayoutAwareBehavior"
         />
+    <adapter
+        factory=".layoutbehavior.layoutAwareTileDataStorage"
+        />
+    <adapter
+        for=".layoutbehavior.ILayoutBehaviorAdaptable
+             * plone.tiles.interfaces.IPersistentTile"
+        factory="plone.tiles.data.defaultTileDataStorage"
+        />
+    <adapter
+        factory=".drafting.LayoutAwareDataStorageSyncher"
+        zcml:condition="installed plone.app.drafts"
+        />
 
     <!-- Register the default views for the layout behavior -->
+    <browser:page
+        for=".layoutbehavior.ILayoutBehaviorAdaptable"
+        name="tile_layout_view"
+        class=".layoutviews.TileLayoutView"
+        permission="cmf.ModifyPortalContent"
+        />
     <browser:page
         for=".layoutbehavior.ILayoutBehaviorAdaptable"
         name="layout_view"

--- a/plone/app/blocks/drafting.py
+++ b/plone/app/blocks/drafting.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from plone.app.blocks.layoutbehavior import ILayoutAware
+from plone.app.blocks.layoutbehavior import ILayoutBehaviorAdaptable
+from plone.app.drafts.interfaces import IDraft
+from plone.app.drafts.interfaces import IDraftSyncer
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@implementer(IDraftSyncer)
+@adapter(IDraft, ILayoutBehaviorAdaptable)
+class LayoutAwareDataStorageSyncher(object):
+    """Copy draft data to the real object on save
+    """
+
+    def __init__(self, draft, target):
+        self.draft = draft
+        self.target = target
+
+    def __call__(self):
+        try:
+            ILayoutAware(self.target).content = self.draft.content
+        except AttributeError:
+            pass

--- a/plone/app/blocks/indexing.py
+++ b/plone/app/blocks/indexing.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from lxml.html import fromstring
 from plone.app.blocks.layoutbehavior import ILayoutAware
+from plone.app.blocks.layoutbehavior import ILayoutBehaviorAdaptable
 from plone.indexer.decorator import indexer
 from plone.tiles.data import ANNOTATIONS_KEY_PREFIX
 from Products.CMFPlone.utils import safe_unicode
@@ -32,7 +33,7 @@ except ImportError:
         return result
 
 
-@indexer(ILayoutAware)
+@indexer(ILayoutBehaviorAdaptable)
 def LayoutSearchableText(obj):
     text = [obj.id]
     try:
@@ -58,17 +59,28 @@ def LayoutSearchableText(obj):
                 val = data.get(field_name)
                 if isinstance(val, basestring):
                     text.append(val)
-    if not behavior_data.contentLayout and behavior_data.content:
-        dom = fromstring(behavior_data.content)
-        text.extend(dom.xpath('//text()'))
 
-    return concat(*text)
+    try:
+        if behavior_data.content:
+            dom = fromstring(behavior_data.content)
+            text.extend(dom.xpath('//text()'))
+    except AttributeError:
+        pass
+
+    try:
+        if behavior_data.customLayout:
+            dom = fromstring(behavior_data.customLayout)
+            text.extend(dom.xpath('//text()'))
+    except AttributeError:
+        pass
+
+    return concat(*set(text))
 
 
 if HAS_DEXTERITYTEXTINDEXER:
 
     @implementer(IDynamicTextIndexExtender)
-    @adapter(ILayoutAware)
+    @adapter(ILayoutBehaviorAdaptable)
     class LayoutSearchableTextIndexExtender(object):
 
         def __init__(self, context):

--- a/plone/app/blocks/indexing.py
+++ b/plone/app/blocks/indexing.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from lxml.html import fromstring
-from lxml.html import tostring
 from plone.app.blocks.layoutbehavior import ILayoutAware
 from plone.indexer.decorator import indexer
 from plone.tiles.data import ANNOTATIONS_KEY_PREFIX
@@ -8,7 +7,6 @@ from Products.CMFPlone.utils import safe_unicode
 from zope.annotation.interfaces import IAnnotations
 from zope.component import adapter
 from zope.interface import implementer
-
 import pkg_resources
 
 
@@ -62,8 +60,7 @@ def LayoutSearchableText(obj):
                     text.append(val)
     if not behavior_data.contentLayout and behavior_data.content:
         dom = fromstring(behavior_data.content)
-        for el in dom.cssselect('.mosaic-text-tile .mosaic-tile-content'):
-            text.append(tostring(el))
+        text.extend(dom.xpath('//text()'))
 
     return concat(*text)
 

--- a/plone/app/blocks/layoutbehavior.py
+++ b/plone/app/blocks/layoutbehavior.py
@@ -63,7 +63,7 @@ class ILayoutAware(model.Schema):
         required=False
     )
 
-    customLayout = LayoutField(
+    customContentLayout = LayoutField(
         title=_(u"Custom layout"),
         description=_(u"Custom content and content layout of this page"),
         default=None,
@@ -101,7 +101,7 @@ class ILayoutAware(model.Schema):
         fields=(
             'content',
             'contentLayout',
-            'customLayout',
+            'customContentLayout',
             'pageSiteLayout',
             'sectionSiteLayout'
         )
@@ -138,7 +138,7 @@ class LayoutAwareDefault(object):
 
     content = None
     contentLayout = None
-    customLayout = None
+    customContentLayout = None
     pageSiteLayout = None
     sectionSiteLayout = None
 
@@ -207,12 +207,12 @@ class LayoutAwareBehavior(LayoutAwareDefault):
         self.context.content = value
 
     @property
-    def customLayout(self):
-        return getattr(self.context, 'customLayout', None)
+    def customContentLayout(self):
+        return getattr(self.context, 'customContentLayout', None)
 
-    @customLayout.setter
-    def customLayout(self, value):
-        self.context.customLayout = value
+    @customContentLayout.setter
+    def customContentLayout(self, value):
+        self.context.customContentLayout = value
 
     @property
     def contentLayout(self):
@@ -249,8 +249,8 @@ class LayoutAwareBehavior(LayoutAwareDefault):
                 return applyTilePersistent(path, resolved)
             except (NotFound, RuntimeError):
                 pass
-        elif self.customLayout:
-            return self.customLayout
+        elif self.customContentLayout:
+            return self.customContentLayout
 
         return super(LayoutAwareBehavior, self).content_layout()
 

--- a/plone/app/blocks/layoutbehavior.py
+++ b/plone/app/blocks/layoutbehavior.py
@@ -419,8 +419,8 @@ class LayoutAwareTileDataStorage(object):
 
     def items(self):
         items = []
-        for el in self.strorage.tree.xpath('//*[@data-tile]'):
-            key = el.get('data-tile', '').split('?', 1)[0].strip('@')
+        for el in self.storage.tree.xpath('//*[@data-tile]'):
+            key = el.get('data-tile').strip('@')
             try:
                 items.append((key, self[key]))
             except KeyError:

--- a/plone/app/blocks/layoutviews.py
+++ b/plone/app/blocks/layoutviews.py
@@ -62,3 +62,27 @@ class ContentLayoutView(DefaultView):
             f for _, f in getAdapters((self.context, self.request), IFilter)
         ]
         return apply_filters(filters, layout)
+
+
+@implementer(IBlocksTransformEnabled)
+class TileLayoutView(DefaultView):
+    """Introspection view for displaying configured tiles saved in 'content'
+    """
+
+    def __call__(self):
+        """Render the contents of the "content" field coming from
+        the ILayoutAware behavior.
+
+        This result is supposed to be transformed by plone.app.blocks.
+        """
+        lookup = ILayoutAware(self.context, None)
+        layout = lookup.tile_layout() if lookup else None
+        if not layout:
+            layout = ERROR_LAYOUT
+
+        # Here we skip legacy portal_transforms and call plone.outputfilters
+        # directly by purpose
+        filters = [
+            f for _, f in getAdapters((self.context, self.request), IFilter)
+        ]
+        return apply_filters(filters, layout)

--- a/plone/app/blocks/profiles/default/metadata.xml
+++ b/plone/app/blocks/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>3000</version>
+  <version>4000</version>
   <dependencies>
     <dependency>profile-plone.resource:default</dependency>
     <dependency>profile-plone.app.registry:default</dependency>

--- a/plone/app/blocks/testing.py
+++ b/plone/app/blocks/testing.py
@@ -28,7 +28,9 @@ class BlocksLayer(PloneSandboxLayer):
         if HAS_PLONE_APP_CONTENTTYPES:
             import plone.app.contenttypes
             self.loadZCML(package=plone.app.contenttypes)
+        import plone.app.tiles
         import plone.app.blocks
+        self.loadZCML(package=plone.app.tiles, name='demo.zcml')
         self.loadZCML(package=plone.app.blocks)
 
         # Register directory for testing

--- a/plone/app/blocks/tests/test_contentlayout.py
+++ b/plone/app/blocks/tests/test_contentlayout.py
@@ -117,7 +117,7 @@ class TestContentLayout(unittest.TestCase):
             layout)
 
     def test_getLayout_custom(self):
-        self.behavior.customLayout = """
+        self.behavior.customContentLayout = """
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html data-layout="./@@default-site-layout">
@@ -148,7 +148,7 @@ class TestContentLayout(unittest.TestCase):
   </div>
 </body>
 </html>"""
-        self.behavior.customLayout = """
+        self.behavior.customContentLayout = """
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html data-layout="./@@default-site-layout">
@@ -177,7 +177,7 @@ class TestContentLayout(unittest.TestCase):
         self.assertTrue('Foobar inserted raw tile' in indexed_data)
 
     def test_on_save_tile_data_is_cleaned(self):
-        self.behavior.customLayout = """
+        self.behavior.customContentLayout = """
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html data-layout="./@@default-site-layout">

--- a/plone/app/blocks/tests/test_contentlayout.py
+++ b/plone/app/blocks/tests/test_contentlayout.py
@@ -117,7 +117,7 @@ class TestContentLayout(unittest.TestCase):
             layout)
 
     def test_getLayout_custom(self):
-        self.behavior.content = """
+        self.behavior.customLayout = """
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html data-layout="./@@default-site-layout">
@@ -143,6 +143,16 @@ class TestContentLayout(unittest.TestCase):
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html data-layout="./@@default-site-layout">
 <body>
+  <div data-tile="./@@plone.app.standardtiles.html/example"
+    <p>Foobar inserted text tile</p>
+  </div>
+</body>
+</html>"""
+        self.behavior.customLayout = """
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html data-layout="./@@default-site-layout">
+<body>
   <div class="mosaic-tile rawhtml-tile
               mosaic-plone.app.standardtiles.rawhtml-tile">
     <div class="mosaic-tile-content">
@@ -151,23 +161,23 @@ class TestContentLayout(unittest.TestCase):
   </div>
   <div class="mosaic-tile mosaic-text-tile">
     <div class="mosaic-tile-content">
-        <p>Foobar inserted text tile</p>
+      <div data-tile="./@@plone.app.standardtiles.html/example"></div>
     </div>
   </div>
 </body>
 </html>"""
-        content = self.portal['f1']['d1']
-        annotations = IAnnotations(content)
+        obj = self.portal['f1']['d1']
+        annotations = IAnnotations(obj)
         annotations[ANNOTATIONS_KEY_PREFIX + '.rawhtml-1'] = {
             'content': '<p>Foobar inserted raw tile</p>'
         }
         from plone.app.blocks.indexing import LayoutSearchableText
-        indexed_data = LayoutSearchableText(content)()
+        indexed_data = LayoutSearchableText(obj)()
         self.assertTrue('Foobar inserted text tile' in indexed_data)
         self.assertTrue('Foobar inserted raw tile' in indexed_data)
 
     def test_on_save_tile_data_is_cleaned(self):
-        self.behavior.content = """
+        self.behavior.customLayout = """
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html data-layout="./@@default-site-layout">
@@ -179,8 +189,8 @@ class TestContentLayout(unittest.TestCase):
 </body>
 </html>"""
 
-        content = self.portal['f1']['d1']
-        annotations = IAnnotations(content)
+        obj = self.portal['f1']['d1']
+        annotations = IAnnotations(obj)
         annotations.update({
             ANNOTATIONS_KEY_PREFIX + '.foobar-1': {
                 'foo': 'bar'
@@ -206,8 +216,8 @@ class TestContentLayout(unittest.TestCase):
         })
 
         from plone.app.blocks.subscribers import onLayoutEdited
-        onLayoutEdited(content, None)
-        annotations = IAnnotations(content)
+        onLayoutEdited(obj, None)
+        annotations = IAnnotations(obj)
         self.assertTrue(ANNOTATIONS_KEY_PREFIX + '.foobar-1' in annotations)
         self.assertTrue(ANNOTATIONS_KEY_PREFIX + '.foobar-2' in annotations)
         self.assertTrue(ANNOTATIONS_KEY_PREFIX + '.foobar-3' in annotations)

--- a/plone/app/blocks/tests/test_layoutbehavior.py
+++ b/plone/app/blocks/tests/test_layoutbehavior.py
@@ -58,7 +58,7 @@ class TestLayoutBehavior(unittest.TestCase):
 
     def test_content(self):
         from plone.app.blocks.layoutviews import ContentLayoutView
-        self.behavior.content = \
+        self.behavior.customLayout = \
             u'<html><body><a href="{0:s}"></a></body></html>'.format(
                 'resolveuid/{0:s}'.format(IUUID(self.portal['f1'])))
         rendered = ContentLayoutView(self.portal['f1']['d1'], self.request)()

--- a/plone/app/blocks/tests/test_layoutbehavior.py
+++ b/plone/app/blocks/tests/test_layoutbehavior.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+from plone.app.blocks.layoutbehavior import ILayoutAware
+from plone.app.blocks.layoutbehavior import ILayoutBehaviorAdaptable
+from plone.app.blocks.layoutbehavior import LayoutAwareBehavior
+from plone.app.blocks.layoutbehavior import LayoutAwareTileDataStorage
 from plone.app.blocks.testing import BLOCKS_FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -6,6 +10,7 @@ from plone.registry.interfaces import IRegistry
 from plone.uuid.interfaces import IUUID
 from zope.component import getGlobalSiteManager
 from zope.component import getUtility
+from zope.interface import alsoProvides
 
 import pkg_resources
 import unittest
@@ -28,35 +33,19 @@ class TestLayoutBehavior(unittest.TestCase):
         self.request = self.layer['request']
         self.registry = getUtility(IRegistry)
 
+        self.portal.portal_types['Document'].behaviors += (
+            'plone.app.blocks.layoutbehavior.ILayoutAware',)
+
         setRoles(self.portal, TEST_USER_ID, ('Manager',))
         self.portal.invokeFactory('Folder', 'f1', title=u"Folder 1")
         self.portal['f1'].invokeFactory('Document', 'd1', title=u"Document 1")
         setRoles(self.portal, TEST_USER_ID, ('Member',))
 
-        if HAS_PLONE_APP_CONTENTTYPES:
-            from plone.app.contenttypes.interfaces import IDocument
-            iface = IDocument
-        else:
-            iface = self.portal['f1']['d1'].__class__
-
-        from plone.app.blocks.layoutbehavior import ILayoutAware
-        from plone.app.blocks.layoutbehavior import LayoutAwareBehavior
-
-        sm = getGlobalSiteManager()
-        sm.registerAdapter(LayoutAwareBehavior, [iface])
-        registrations = sm.getAdapters(
-            (self.portal['f1']['d1'],),
-            ILayoutAware
-        )
-        self.assertEqual(len(list(registrations)), 1)
         self.behavior = ILayoutAware(self.portal['f1']['d1'])
-        registrations = sm.getAdapters(
-            (self.portal['f1']['d1'],),
-            ILayoutAware
-        )
-        self.assertEqual(len(list(registrations)), 1)
+        self.assertTrue(
+            ILayoutBehaviorAdaptable.providedBy(self.behavior.context))
 
-    def test_content(self):
+    def test_custom_content_layout(self):
         from plone.app.blocks.layoutviews import ContentLayoutView
         self.behavior.customContentLayout = \
             u'<html><body><a href="{0:s}"></a></body></html>'.format(
@@ -66,3 +55,37 @@ class TestLayoutBehavior(unittest.TestCase):
         # Test that UUID is resolved by outputfilters
         self.assertNotIn(IUUID(self.portal['f1']), rendered)
         self.assertIn(self.portal['f1'].absolute_url(), rendered)
+
+    def test_content(self):
+        tile = 'plone.app.tiles.demo.transient/demo'
+        self.behavior.content = u"""\
+<html>
+<body>
+<div data-tile="@@plone.app.tiles.demo.transient/demo"
+data-tiledata='{"message": "Hello World!"}' />
+</body>
+</html>
+"""
+        view = self.portal['f1']['d1'].restrictedTraverse(tile)()
+        self.assertEqual(
+            view,
+            '<html><body><b>Transient tile Hello World!</b></body></html>'
+        )
+
+        storage = LayoutAwareTileDataStorage(self.portal['f1']['d1'],
+                                             self.layer['request'])
+        self.assertEqual(len(storage), 1)
+        self.assertEqual(list(storage), [tile])
+        self.assertEqual(storage[tile]['message'], u"Hello World!")
+
+        data = storage[tile]
+        data['message'] = u"Foo bar!"
+        storage[tile] = data
+
+        delattr(self.layer['request'], '__annotations__')  # purge memoize
+
+        view = self.portal['f1']['d1'].restrictedTraverse(tile)()
+        self.assertEqual(
+            view,
+            '<html><body><b>Transient tile Foo bar!</b></body></html>'
+        )

--- a/plone/app/blocks/tests/test_layoutbehavior.py
+++ b/plone/app/blocks/tests/test_layoutbehavior.py
@@ -58,7 +58,7 @@ class TestLayoutBehavior(unittest.TestCase):
 
     def test_content(self):
         from plone.app.blocks.layoutviews import ContentLayoutView
-        self.behavior.customLayout = \
+        self.behavior.customContentLayout = \
             u'<html><body><a href="{0:s}"></a></body></html>'.format(
                 'resolveuid/{0:s}'.format(IUUID(self.portal['f1'])))
         rendered = ContentLayoutView(self.portal['f1']['d1'], self.request)()

--- a/plone/app/blocks/tests/test_layoutbehavior.py
+++ b/plone/app/blocks/tests/test_layoutbehavior.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 from plone.app.blocks.layoutbehavior import ILayoutAware
 from plone.app.blocks.layoutbehavior import ILayoutBehaviorAdaptable
-from plone.app.blocks.layoutbehavior import LayoutAwareBehavior
 from plone.app.blocks.layoutbehavior import LayoutAwareTileDataStorage
 from plone.app.blocks.testing import BLOCKS_FUNCTIONAL_TESTING
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.registry.interfaces import IRegistry
 from plone.uuid.interfaces import IUUID
-from zope.component import getGlobalSiteManager
 from zope.component import getUtility
-from zope.interface import alsoProvides
 
 import pkg_resources
 import unittest
@@ -33,8 +30,14 @@ class TestLayoutBehavior(unittest.TestCase):
         self.request = self.layer['request']
         self.registry = getUtility(IRegistry)
 
-        self.portal.portal_types['Document'].behaviors += (
-            'plone.app.blocks.layoutbehavior.ILayoutAware',)
+        # Enable layout aware behavior
+        fti = self.portal.portal_types['Document']
+        behaviors = [i for i in fti.behaviors]
+        behaviors.extend([
+            'plone.app.blocks.layoutbehavior.ILayoutAware'
+        ])
+        behaviors = tuple(set(behaviors))
+        fti._updateProperty('behaviors', behaviors)
 
         setRoles(self.portal, TEST_USER_ID, ('Manager',))
         self.portal.invokeFactory('Folder', 'f1', title=u"Folder 1")

--- a/plone/app/blocks/tests/test_page_sitelayout.py
+++ b/plone/app/blocks/tests/test_page_sitelayout.py
@@ -79,7 +79,7 @@ class TestPageSiteLayout(unittest.TestCase):
         self.assertTrue(u"Layout title" in rendered)
 
     def test_page_site_layout_page_override(self):
-        self.behavior.customLayout = u"<html><body>N/A</body></html>"
+        self.behavior.customContentLayout = u"<html><body>N/A</body></html>"
         self.behavior.pageSiteLayout = \
             '/++sitelayout++testlayout2/mylayout.html'
 
@@ -130,7 +130,7 @@ class TestPageSiteLayout(unittest.TestCase):
         self.assertTrue(u"My Layout 1 Title" in rendered)
 
     def test_page_site_layout_cache_invalidate_mtime(self):
-        self.behavior.customLayout = u"<html><body>N/A</body></html>"
+        self.behavior.customContentLayout = u"<html><body>N/A</body></html>"
         self.behavior.sectionSiteLayout = \
             '/++sitelayout++testlayout2/mylayout.html'
 

--- a/plone/app/blocks/tests/test_page_sitelayout.py
+++ b/plone/app/blocks/tests/test_page_sitelayout.py
@@ -79,7 +79,7 @@ class TestPageSiteLayout(unittest.TestCase):
         self.assertTrue(u"Layout title" in rendered)
 
     def test_page_site_layout_page_override(self):
-        self.behavior.content = u"<html><body>N/A</body></html>"
+        self.behavior.customLayout = u"<html><body>N/A</body></html>"
         self.behavior.pageSiteLayout = \
             '/++sitelayout++testlayout2/mylayout.html'
 
@@ -130,7 +130,7 @@ class TestPageSiteLayout(unittest.TestCase):
         self.assertTrue(u"My Layout 1 Title" in rendered)
 
     def test_page_site_layout_cache_invalidate_mtime(self):
-        self.behavior.content = u"<html><body>N/A</body></html>"
+        self.behavior.customLayout = u"<html><body>N/A</body></html>"
         self.behavior.sectionSiteLayout = \
             '/++sitelayout++testlayout2/mylayout.html'
 

--- a/plone/app/blocks/tests/test_sitelayout.py
+++ b/plone/app/blocks/tests/test_sitelayout.py
@@ -91,7 +91,7 @@ class TestSiteLayout(unittest.TestCase):
             def __init__(self, context):
                 self.context = context
 
-            customLayout = u"<html><body>N/A</body></html>"
+            customContentLayout = u"<html><body>N/A</body></html>"
             sectionSiteLayout = '/++sitelayout++testlayout2/mylayout.html'
             pageSiteLayout = None
 

--- a/plone/app/blocks/tests/test_sitelayout.py
+++ b/plone/app/blocks/tests/test_sitelayout.py
@@ -91,7 +91,7 @@ class TestSiteLayout(unittest.TestCase):
             def __init__(self, context):
                 self.context = context
 
-            content = u"<html><body>N/A</body></html>"
+            customLayout = u"<html><body>N/A</body></html>"
             sectionSiteLayout = '/++sitelayout++testlayout2/mylayout.html'
             pageSiteLayout = None
 

--- a/plone/app/blocks/upgrades.py
+++ b/plone/app/blocks/upgrades.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
 
+from plone.app.blocks.layoutbehavior import ILayoutAware
+from plone.app.blocks.layoutbehavior import ILayoutBehaviorAdaptable
 
 PROFILE_ID = 'profile-plone.app.blocks:default'
 
@@ -13,3 +15,21 @@ def upgrade_settings(context):
 def upgrade_rolemap(context):
     setup = getToolByName(context, 'portal_setup')
     setup.runImportStepFromProfile(PROFILE_ID, 'rolemap')
+
+
+def migrate_content_to_customContentLayout(context):
+    pc = getToolByName(context, 'portal_catalog')
+    brains = []
+    brains.extend(pc.unrestrictedSearchResults(
+        object_provides=ILayoutAware.__identifier__))
+    brains.extend(pc.unrestrictedSearchResults(
+        object_provides=ILayoutBehaviorAdaptable.__identifier__))
+    for brain in brains:
+        ob = brain._unrestrictedGetObject()
+        adapted = ILayoutAware(ob)
+        if all([
+            not getattr(adapted, 'customContentLayout', None),
+            getattr(adapted, 'content', None)
+        ]):
+            adapted.customContentLayout = adapted.content
+            adapted.content = None

--- a/plone/app/blocks/upgrades.zcml
+++ b/plone/app/blocks/upgrades.zcml
@@ -18,4 +18,12 @@
       handler=".upgrades.upgrade_rolemap"
       />
 
+  <genericsetup:upgradeStep
+      profile="plone.app.blocks:default"
+      source="3000"
+      destination="4000"
+      title="Migrate content to customContentLayout"
+      handler=".upgrades.migrate_content_to_customContentLayout"
+      />
+
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Plone',
-        'Framework :: Plone :: 4.3',
         'Framework :: Plone :: 5.0',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'plone.autoform',
         'plone.behavior>=1.1',
         'plone.dexterity',
+        'plone.jsonserializer',
         'plone.memoize',
         'plone.outputfilters',
         'plone.registry',

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ widgets_require = [
     'plone.app.widgets'
 ]
 test_require = [
+    'plone.app.tiles',
     'plone.app.testing',
     'plone.testing',
     'Products.BTreeFolder2',


### PR DESCRIPTION
Possibly still WIP.

* [x] some new tests
* [x] use JSON instead of querystrings for saving content data
* [x] upgrade step to move existing data from 'content' to 'customLayout'

This pull changes custom layout field from 'content' to custom layout.
This re-introduces 'content' field as layout like tile data content storage.

Depends on https://github.com/plone/plone.tiles/pull/12