### PR TITLE
Fix a couple of edge cases in resolveResource

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,15 @@ Changelog
 4.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Fixes:
+
+- Fix issue where default layouts paths were not found if they were stored
+  unicode (TextLine) instead of str (ASCIILine or BytesLine)
+  [datakurre]
+
+- Fix issue where tiles merge failed for addresses with space, because
+  subrequest was called with quoted ('%20') paths
+  [datakurre]
 
 
 4.0.2 (2017-01-03)

--- a/plone/app/blocks/utils.py
+++ b/plone/app/blocks/utils.py
@@ -22,6 +22,7 @@ from zope.site.hooks import getSite
 
 import Globals
 import logging
+import urllib
 import zope.deferredimport
 
 
@@ -93,6 +94,7 @@ def resolveResource(url):
     """Resolve the given URL to a unicode string. If the URL is an absolute
     path, it will be made relative to the Plone site root.
     """
+    url = urllib.unquote(url)  # subrequest does not support quoted paths
     if url.count('++') == 2:
         # it is a resource that can be resolved without a subrequest
         _, resource_type, path = url.split('++')

--- a/plone/app/blocks/utils.py
+++ b/plone/app/blocks/utils.py
@@ -98,6 +98,8 @@ def resolveResource(url):
         _, resource_type, path = url.split('++')
         resource_name, _, path = path.partition('/')
         directory = queryResourceDirectory(resource_type, resource_name)
+        if isinstance(path, unicode):
+            path = path.encode('utf-8', 'replace')
         if directory:
             try:
                 return directory.readFile(path)


### PR DESCRIPTION
1) I had a few issues where, in some reason, I had stored default layout paths into registry as TextLines intead of ASCIILines. That caused resolveResource to fail, becaus it did direct resource directory lookup using unicode string, which is unsupported (resource directory does internally restricted traverse, which does not support unicode, but thinks it is a list).

2) If content object has space in its name, resolveResource failed, because the space was already quoted as %20 causing 404 NotFound in restrictedTraverse of subrequest.