### PR TITLE
Add 'permission' key for content layout manifest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ New Features:
   it's really required.
   [datakurre]
 
+- Add to allow ``permission`` key in ``[contentlayout]``-sections of content
+  layout manifests (``manifest.cfg``)
+  [datakurre]
+
 
 4.0.6 (2017-02-09)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -99,10 +99,13 @@ To create such a manifest, put a ``manifest.cfg`` file in the layout directory w
     file = some-html-file.html
     screenshot = mylayout.png
     for = Document,Folder
+    permission = cmf.ModifyPortalContent
 
 * All keys are optional.
-* The file defaults to ``content.html``.
+* Value for key ``file`` defaults to ``content.html``.
 * Single manifest may contain multiple ``[contentlayout]`` sections.
+* Values for keys ``for`` and ``permission`` are only for advisory and may not
+  be enforced.
 
 A vocabulary factory called ``plone.availableContentLayouts`` is registered to allow lookup of all registered content layouts.
 The terms in this vocabulary use the URL as a value,

--- a/plone/app/blocks/interfaces.py
+++ b/plone/app/blocks/interfaces.py
@@ -19,7 +19,7 @@ SITE_LAYOUT_MANIFEST_FORMAT = ManifestFormat(
 CONTENT_LAYOUT_MANIFEST_FORMAT = ManifestFormat(
     CONTENT_LAYOUT_RESOURCE_NAME,
     keys=('title', 'description', 'file', 'screenshot',
-          'preview', 'sort_key', 'for'),
+          'preview', 'sort_key', 'for', 'permission'),
     defaults={'file': CONTENT_LAYOUT_FILE_NAME}
 )
 


### PR DESCRIPTION
This does nothing by itself, but with respective change to Plone Mosaic, it's possible to user permissions to filter, which layouts are visible to which editors.