### PR TITLE
Fix issue: configuring tiles with accented tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ New Features:
   layout manifests (``manifest.cfg``)
   [datakurre]
 
+Fixes:
+
+- Fix issue when someone tries to configure tiles with accented tags
 
 4.0.6 (2017-02-09)
 ------------------

--- a/plone/app/blocks/layoutbehavior.py
+++ b/plone/app/blocks/layoutbehavior.py
@@ -356,6 +356,8 @@ class LayoutAwareTileDataStorage(object):
                         data[name] = primary
                         break
 
+            data['tags'] = [tag.encode('utf-8') for tag in data['tags']]
+            
             return schema_compatible(data, schema_)
         raise KeyError(key)
 


### PR DESCRIPTION
The process of configure tiles with accented tags fails. My workaround for this is to encode all tags, although these have no accents because it works anyway