### PR TITLE
Add more context to before/after tile rendering notification

### DIFF
--- a/plone/app/blocks/events.py
+++ b/plone/app/blocks/events.py
@@ -6,8 +6,9 @@ from zope.interface import implementer
 
 class BaseTileRenderEvent(object):
 
-    def __init__(self, tile_href):
+    def __init__(self, tile_href, tile_node):
         self.tile_href = tile_href
+        self.tile_node = tile_node
 
 
 @implementer(IBeforeTileRenderEvent)

--- a/plone/app/blocks/interfaces.py
+++ b/plone/app/blocks/interfaces.py
@@ -90,6 +90,7 @@ class IBaseTileRenderEvent(Interface):
     """Base class for tile render events.
     """
     tile_href = Attribute('URL of the rendered tile')
+    tile_node = Attribute('LXML.html node on which the tile is called')
 
 
 class IBeforeTileRenderEvent(IBaseTileRenderEvent):

--- a/plone/app/blocks/tiles.py
+++ b/plone/app/blocks/tiles.py
@@ -51,7 +51,7 @@ def renderTiles(request, tree):
         if not tileHref.startswith('/'):
             tileHref = urljoin(baseURL, tileHref)
 
-        notify(events.BeforeTileRenderEvent(tileHref))
+        notify(events.BeforeTileRenderEvent(tileHref, tileNode))
         try:
             tileTree = utils.resolve(tileHref)
         except RuntimeError:
@@ -66,7 +66,7 @@ def renderTiles(request, tree):
         if tileTree is not None:
             tileRoot = tileTree.getroot()
             utils.replace_with_children(tileNode, tileRoot.find('head'))
-        notify(events.AfterTileRenderEvent(tileHref))
+        notify(events.AfterTileRenderEvent(tileHref, tileNode))
 
     for tileNode in utils.bodyTileXPath(tree):
         tileHref = tileNode.attrib[utils.tileAttrib]
@@ -75,7 +75,7 @@ def renderTiles(request, tree):
         if not tileHref.startswith('/'):
             tileHref = urljoin(baseURL, tileHref)
 
-        notify(events.BeforeTileRenderEvent(tileHref))
+        notify(events.BeforeTileRenderEvent(tileHref, tileNode))
         try:
             tileTree = utils.resolve(tileHref)
         except RuntimeError:
@@ -116,6 +116,6 @@ def renderTiles(request, tree):
                 for tileHeadChild in tileHead:
                     headNode.append(tileHeadChild)
             utils.replace_with_children(tileNode, tileBody)
-        notify(events.AfterTileRenderEvent(tileHref))
+        notify(events.AfterTileRenderEvent(tileHref, tileNode))
 
     return tree


### PR DESCRIPTION
Using these events I profile the processing time for each tile. On IBeforeTileRenderEvent I store the start time to a global dict and on end time I read it from that.

Using only the tile_href is not enough when there are two of the same tiles. Therefore I added the tile_node also to give more context. Now my dict key is made up like this:
```
'%s %s' % (event.tile_href, id(event.tile_node))
```