### PR TITLE
Thet tilerenderfixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ New features:
 
 Bug fixes:
 
+- Allow head tiles without a html/head structure.
+  [thet]
+
 - Fix issue where resolving layout url with ajax_load parameter caused fail
   on direct resolve directory lookup
   [datakurre]

--- a/plone/app/blocks/tests/test_tiles.py
+++ b/plone/app/blocks/tests/test_tiles.py
@@ -197,6 +197,20 @@ testLayout3 = """\
 </html>
 """
 
+testLayout4 = """\
+<!DOCTYPE html>
+<html>
+<head>
+  <div data-tile="./@@test.tile1.broken"/>
+  <div data-tile="./@@tiledoesnotexist"/>
+</head>
+<body>
+  <h1>hi there!</h1>
+  <div data-tile="./@@tiledoesnotexist"/>
+</body>
+</html>
+"""
+
 
 class TestRenderTiles(unittest.TestCase):
 
@@ -246,3 +260,14 @@ class TestRenderTiles(unittest.TestCase):
 
         self.assertIn("structureless in head", result)
         self.assertIn("structureless in body", result)
+
+    def testRenderStructurelessTile(self):
+        """Test if non-existent or broken tiles do not end in an recursive loop.
+        """
+        serializer = getHTMLSerializer([testLayout4])
+        request = self.layer['request']
+        tree = serializer.tree
+        renderTiles(request, tree)
+        result = serializer.serialize()
+
+        self.assertIn("hi there!", result)

--- a/plone/app/blocks/tests/test_tiles.py
+++ b/plone/app/blocks/tests/test_tiles.py
@@ -237,7 +237,7 @@ class TestRenderTiles(unittest.TestCase):
         self.assertIn('There was an error while rendering this tile', result)
         self.assertIn('This is a demo tile with id tile4', result)
 
-    def testRenderSubTile(self):
+    def testRenderSubTiles(self):
         """Test if subtiles - tiles referenced in tiles - are resolved.
         """
         serializer = getHTMLSerializer([testLayout3])
@@ -249,7 +249,7 @@ class TestRenderTiles(unittest.TestCase):
         self.assertIn("I'm a tile calling another tile as subtile.", result)
         self.assertIn("This is a demo tile with id subtile", result)
 
-    def testRenderStructurelessTile(self):
+    def testRenderStructurelessTiles(self):
         """Test if tiles without a html/head/body structure are also rendered.
         """
         serializer = getHTMLSerializer([testLayout3])
@@ -261,7 +261,7 @@ class TestRenderTiles(unittest.TestCase):
         self.assertIn("structureless in head", result)
         self.assertIn("structureless in body", result)
 
-    def testRenderStructurelessTile(self):
+    def testNonExistentAndBrokenTiiles(self):
         """Test if non-existent or broken tiles do not end in an recursive loop.
         """
         serializer = getHTMLSerializer([testLayout4])

--- a/plone/app/blocks/tiles.py
+++ b/plone/app/blocks/tiles.py
@@ -60,6 +60,10 @@ def renderTiles(request, tree):
             tileTree = None
         except NotFound:
             logger.warn('NotFound while trying to render tile: %s', tileHref)
+
+        if tileTree is None:
+            utils.remove_element(tileNode)
+            notify(events.AfterTileRenderEvent(tileHref, tileNode))
             continue
 
         if tileTree is not None:
@@ -85,6 +89,11 @@ def renderTiles(request, tree):
         except RuntimeError:
             tileTree = errorTile(request)
         except NotFound:
+            logger.warn('NotFound while trying to render tile: %s', tileHref)
+
+        if tileTree is None:
+            utils.remove_element(tileNode)
+            notify(events.AfterTileRenderEvent(tileHref, tileNode))
             continue
 
         tileTransform = None

--- a/plone/app/blocks/utils.py
+++ b/plone/app/blocks/utils.py
@@ -205,6 +205,11 @@ def replace_content(element, wrapper):
         element.extend(wrapper.getchildren())
 
 
+def remove_element(element):
+    parent = element.getparent()
+    parent.remove(element)
+
+
 class PermissionChecker(object):
 
     def __init__(self, permissions, context):


### PR DESCRIPTION
- Allow head tiles without a html/head structure.  In body tiles this was already possible.
- Fix tile rendering where non-existent or broken tiles end up in a recursive loop since #66 - "Allow rendering of subtiles"