### PR TITLE
Enforce plone.subrequest >= 1.7.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking chnages:
 
 Bug fixes:
 
-- Nothing changed yet.
+- Enforce usage of plone.subrequest >= 1.7.0;
+  this avoids ``TypeError`` on package upgrades (refs. `#62 <https://github.com/plone/plone.app.blocks/issues/62>`_).
+  [hvelarde]
 
 New features:
 

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         'plone.outputfilters',
         'plone.registry',
         'plone.resource',
-        'plone.subrequest',
+        'plone.subrequest >= 1.7.0',
         'plone.supermodel',
         'plone.tiles',
         'plone.transformchain',


### PR DESCRIPTION
This avoids `TypeError` on package upgrades.

closes #62 