### PR TITLE
getSite from zope.component.hooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 4.3.3 (unreleased)
 ------------------
 
+- getSite from zope.component.hooks
+  [ksuess]
 - Fix unicode parsing error on Python 3, resulting in empty mosaic page (`#62 https://github.com/plone/plone.app.mosaic/issues/480`_).
   [agitator]
 

--- a/plone/app/blocks/resource.py
+++ b/plone/app/blocks/resource.py
@@ -32,7 +32,7 @@ from zope.publisher.browser import BrowserView
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
-from zope.site.hooks import getSite
+from zope.component.hooks import getSite
 
 import logging
 import six

--- a/plone/app/blocks/utils.py
+++ b/plone/app/blocks/utils.py
@@ -20,7 +20,7 @@ from zExceptions import Unauthorized
 from zope.component import getMultiAdapter
 from zope.component import queryUtility
 from zope.security.interfaces import IPermission
-from zope.site.hooks import getSite
+from zope.component.hooks import getSite
 
 import logging
 import six


### PR DESCRIPTION
plone.app.blocks/plone/app/blocks/utils.py:23: DeprecationWarning: zope.site.hooks has moved to zope.component.hooks. Import of zope.site.hooks will become unsupported in Version 5.0
  from zope.site.hooks import getSite