### PR TITLE
Link integrity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support for link integrity for tiles that needs it
+  [gotcha, Mychae1]
 
 
 5.0.1 (2022-03-23)

--- a/plone/app/blocks/configure.zcml
+++ b/plone/app/blocks/configure.zcml
@@ -228,4 +228,8 @@
         zcml:condition="installed collective.dexteritytextindexer"
         />
 
+    <adapter factory=".linkintegrity.BlocksDXGeneral" />
+    <adapter factory=".linkintegrity.TileGeneral" />
+    <adapter factory=".linkintegrity.HTMLTile" />
+    <adapter factory=".linkintegrity.ExistingContentTile" />
 </configure>

--- a/plone/app/blocks/linkintegrity.py
+++ b/plone/app/blocks/linkintegrity.py
@@ -1,0 +1,108 @@
+import re
+
+from plone.app.blocks.layoutbehavior import ILayoutBehaviorAdaptable
+from plone.app.blocks import utils
+from plone.app.linkintegrity.interfaces import IRetriever
+from plone.app.linkintegrity.parser import extractLinks
+from plone.app.linkintegrity.retriever import DXGeneral
+from plone.app.standardtiles import html
+from plone.app.standardtiles import existingcontent
+from plone.tiles.interfaces import ITile
+from repoze.xmliter.utils import getHTMLSerializer
+from zope.component import adapter
+from zope.interface import implementer
+try:
+    # Plone 5.2+
+    from Products.CMFPlone.utils import safe_bytes
+except ImportError:
+    # BBB for Plone 5.1
+    from Products.CMFPlone.utils import safe_encode as safe_bytes
+
+
+@implementer(IRetriever)
+@adapter(ILayoutBehaviorAdaptable)
+class BlocksDXGeneral(DXGeneral):
+    """General retriever for DX that extracts URLs from (rich) text fields.
+    """
+
+    def __init__(self, context):
+        self.context = context
+
+    def retrieveLinks(self):
+        """Finds all links from the object and return them.
+        """
+        links = super(BlocksDXGeneral, self).retrieveLinks()
+        links |= self.retrieveLinksFromTiles()
+        return links
+
+    def retrieveLinksFromTiles(self):
+
+        links = set()
+
+        if self.context.customContentLayout is None:
+            return links
+
+        iterable = [
+            re.sub(b"&#13;", b"\n", re.sub(b"&#13;\n", b"\n", safe_bytes(item)))
+            for item in self.context.customContentLayout
+            if item
+        ]
+        result = getHTMLSerializer(
+            # safe_bytes (called just before) assumes 'utf-8' encoding
+            # thus, we use it here as well
+            # if other encoding is needed, those are two places to change
+            iterable, pretty_print=False, encoding='utf-8'
+        )
+
+
+        for tile_node in utils.bodyTileXPath(result.tree):
+            tile_url = tile_node.attrib[utils.tileAttrib]
+            # assume request query parameters are always useless
+            # thus ignore any chars from '?'
+            tile_name = tile_url.split('?')[0]
+            # eat first two characters of url ('./')
+            tile_name = tile_name[2:]
+            tile = self.context.restrictedTraverse(tile_name)
+            links |= IRetriever(tile).retrieveLinks()
+
+        return links
+
+
+@implementer(IRetriever)
+@adapter(ITile)
+class TileGeneral(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def retrieveLinks(self):
+        return set()
+
+
+@implementer(IRetriever)
+@adapter(html.HTMLTile)
+class HTMLTile(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def retrieveLinks(self):
+        content = self.context.data['content']
+        # layout behavior tile storage hard codes 'utf-8' encoding
+        # thus we do the same.
+        links = set(extractLinks(content, 'utf-8'))
+        return links
+
+
+@implementer(IRetriever)
+@adapter(existingcontent.ExistingContentTile)
+class ExistingContentTile(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def retrieveLinks(self):
+        content_uid = self.context.data['content_uid']
+        links = set(['../resolveuid/%s' % content_uid])
+        return links
+


### PR DESCRIPTION
Add event subscriber to setup link integrity.

Register adapters for tiles that have content which deserves link integrity.

Once and if merged to 5.x, we would work on forward port to master.