### PR TITLE
Moved tile integration for linkintegrity to plone.app.standardtiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 5.1.1 (unreleased)
 ------------------
 
+- Moved specific tile integration for linkintegrity to ``plone.app.standardtiles``.
+  Fixes `issue 95 <https://github.com/plone/plone.app.blocks/issues/95>`_.
+  [maurits]
+
 - Fix AttributeError in linkintegrity code when pasting a page with tiles.
   Fixes `issue 97 <https://github.com/plone/plone.app.blocks/issues/97>`_.
   [maurits]

--- a/plone/app/blocks/configure.zcml
+++ b/plone/app/blocks/configure.zcml
@@ -230,6 +230,5 @@
 
     <adapter factory=".linkintegrity.BlocksDXGeneral" />
     <adapter factory=".linkintegrity.TileGeneral" />
-    <adapter factory=".linkintegrity.HTMLTile" />
-    <adapter factory=".linkintegrity.ExistingContentTile" />
+
 </configure>

--- a/plone/app/blocks/linkintegrity.py
+++ b/plone/app/blocks/linkintegrity.py
@@ -4,10 +4,7 @@ from Acquisition import aq_parent
 from plone.app.blocks.layoutbehavior import ILayoutBehaviorAdaptable
 from plone.app.blocks import utils
 from plone.app.linkintegrity.interfaces import IRetriever
-from plone.app.linkintegrity.parser import extractLinks
 from plone.app.linkintegrity.retriever import DXGeneral
-from plone.app.standardtiles import html
-from plone.app.standardtiles import existingcontent
 from plone.tiles.interfaces import ITile
 from repoze.xmliter.utils import getHTMLSerializer
 from zope.component import adapter
@@ -86,32 +83,3 @@ class TileGeneral(object):
 
     def retrieveLinks(self):
         return set()
-
-
-@implementer(IRetriever)
-@adapter(html.HTMLTile)
-class HTMLTile(object):
-
-    def __init__(self, context):
-        self.context = context
-
-    def retrieveLinks(self):
-        content = self.context.data['content']
-        # layout behavior tile storage hard codes 'utf-8' encoding
-        # thus we do the same.
-        links = set(extractLinks(content, 'utf-8'))
-        return links
-
-
-@implementer(IRetriever)
-@adapter(existingcontent.ExistingContentTile)
-class ExistingContentTile(object):
-
-    def __init__(self, context):
-        self.context = context
-
-    def retrieveLinks(self):
-        content_uid = self.context.data['content_uid']
-        links = set(['../resolveuid/%s' % content_uid])
-        return links
-


### PR DESCRIPTION
This includes the fix from my PR #98 from earlier today. I needed them both.

You can test this together with https://github.com/plone/plone.app.standardtiles/pull/136