### PR TITLE
Fix layout_view and tile_layout_view to work with the Zope security fix. [6.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 6.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix ``layout_view`` and ``tile_layout_view`` to work with the Zope security fix.
+  Needed when you use Plone 5.2.10.1 or Plone 6.0.0.1.
+  Fixes `issue 101 <https://github.com/plone/plone.app.blocks/issues/101>_`.
+  [maurits]
 
 
 6.0.1 (2022-07-20)

--- a/plone/app/blocks/layoutviews.py
+++ b/plone/app/blocks/layoutviews.py
@@ -57,9 +57,9 @@ class ContentLayoutView(DefaultView):
         # directly by purpose
         filters = [f for _, f in getAdapters((self.context, self.request), IFilter)]
         result = apply_filters(filters, layout)
-        if not self.request.response.getHeader('Content-Type'):
+        if not self.request.response.getHeader("Content-Type"):
             # Needed since Plone 5.2.10.1/6.0.0.1 with Zope security fix.
-            self.request.response.setHeader('Content-Type', 'text/html')
+            self.request.response.setHeader("Content-Type", "text/html")
         return result
 
 
@@ -101,7 +101,7 @@ class TileLayoutView(DefaultView):
         # directly by purpose
         filters = [f for _, f in getAdapters((self.context, self.request), IFilter)]
         result = apply_filters(filters, layout)
-        if not self.request.response.getHeader('Content-Type'):
+        if not self.request.response.getHeader("Content-Type"):
             # Needed since Plone 5.2.10.1/6.0.0.1 with Zope security fix.
-            self.request.response.setHeader('Content-Type', 'text/html')
+            self.request.response.setHeader("Content-Type", "text/html")
         return result

--- a/plone/app/blocks/layoutviews.py
+++ b/plone/app/blocks/layoutviews.py
@@ -56,7 +56,11 @@ class ContentLayoutView(DefaultView):
         # Here we skip legacy portal_transforms and call plone.outputfilters
         # directly by purpose
         filters = [f for _, f in getAdapters((self.context, self.request), IFilter)]
-        return apply_filters(filters, layout)
+        result = apply_filters(filters, layout)
+        if not self.request.response.getHeader('Content-Type'):
+            # Needed since Plone 5.2.10.1/6.0.0.1 with Zope security fix.
+            self.request.response.setHeader('Content-Type', 'text/html')
+        return result
 
 
 @implementer(IBlocksTransformEnabled)
@@ -96,4 +100,8 @@ class TileLayoutView(DefaultView):
         # Here we skip legacy portal_transforms and call plone.outputfilters
         # directly by purpose
         filters = [f for _, f in getAdapters((self.context, self.request), IFilter)]
-        return apply_filters(filters, layout)
+        result = apply_filters(filters, layout)
+        if not self.request.response.getHeader('Content-Type'):
+            # Needed since Plone 5.2.10.1/6.0.0.1 with Zope security fix.
+            self.request.response.setHeader('Content-Type', 'text/html')
+        return result


### PR DESCRIPTION
Needed when you use Plone 5.2.10.1 or Plone 6.0.0.1. Fixes https://github.com/plone/plone.app.blocks/issues/101.