### PR TITLE
Fix layout_view and tile_layout_view to work with the Zope security fix. [5.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 5.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix ``layout_view`` and ``tile_layout_view`` to work with the Zope security fix.
+  Needed when you use Plone 5.2.10.1 or Plone 6.0.0.1.
+  Fixes `issue 101 <https://github.com/plone/plone.app.blocks/issues/101>_`.
+  [maurits]
 
 
 5.2.0 (2022-09-21)

--- a/plone/app/blocks/layoutviews.py
+++ b/plone/app/blocks/layoutviews.py
@@ -57,7 +57,11 @@ class ContentLayoutView(DefaultView):
         # Here we skip legacy portal_transforms and call plone.outputfilters
         # directly by purpose
         filters = [f for _, f in getAdapters((self.context, self.request), IFilter)]
-        return apply_filters(filters, layout)
+        result = apply_filters(filters, layout)
+        if not self.request.response.getHeader('Content-Type'):
+            # Needed since Plone 5.2.10.1/6.0.0.1 with Zope security fix.
+            self.request.response.setHeader('Content-Type', 'text/html')
+        return result
 
 
 @implementer(IBlocksTransformEnabled)
@@ -97,4 +101,8 @@ class TileLayoutView(DefaultView):
         # Here we skip legacy portal_transforms and call plone.outputfilters
         # directly by purpose
         filters = [f for _, f in getAdapters((self.context, self.request), IFilter)]
-        return apply_filters(filters, layout)
+        result = apply_filters(filters, layout)
+        if not self.request.response.getHeader('Content-Type'):
+            # Needed since Plone 5.2.10.1/6.0.0.1 with Zope security fix.
+            self.request.response.setHeader('Content-Type', 'text/html')
+        return result


### PR DESCRIPTION
Needed when you use Plone 5.2.10.1 or Plone 6.0.0.1. Fixes https://github.com/plone/plone.app.blocks/issues/101.