### PR TITLE
Linkintegrity: fix old values for `customContentLayout` which is bytes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 - Fix deprecated dependencies to ``Products.CMFPlone``.
   [petschki]
 
+- Linkintegrity: convert old ``customContentLayout`` data to unicode.
+  [petschki]
+
 
 7.0.0 (2022-12-21)
 ------------------

--- a/plone/app/blocks/linkintegrity.py
+++ b/plone/app/blocks/linkintegrity.py
@@ -4,6 +4,7 @@ from plone.app.blocks.layoutbehavior import ILayoutBehaviorAdaptable
 from plone.app.linkintegrity.interfaces import IRetriever
 from plone.app.linkintegrity.retriever import DXGeneral
 from plone.base.utils import safe_bytes
+from plone.base.utils import safe_text
 from plone.tiles.interfaces import ITile
 from repoze.xmliter.utils import getHTMLSerializer
 from zope.component import adapter
@@ -43,7 +44,7 @@ class BlocksDXGeneral(DXGeneral):
 
         iterable = [
             re.sub(b"&#13;", b"\n", re.sub(b"&#13;\n", b"\n", safe_bytes(item)))
-            for item in self.context.customContentLayout
+            for item in safe_text(self.context.customContentLayout)
             if item
         ]
         result = getHTMLSerializer(


### PR DESCRIPTION
We've been hit by that in a migrated site. I don't know exactly why, but the value of `context.customContentLayout` was bytes.