### PR TITLE
Fix requirements.txt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Fix deprecated dependencies to ``Products.CMFPlone``.
   [petschki]
+- Fix requirements.txt, --install-options is obsolete, use --pre instead
+  [cillianderoiste]
 
 
 7.0.0 (2022-12-21)

--- a/plone/app/blocks/linkintegrity.py
+++ b/plone/app/blocks/linkintegrity.py
@@ -27,7 +27,6 @@ class BlocksDXGeneral(DXGeneral):
         return links
 
     def retrieveLinksFromTiles(self):
-
         links = set()
 
         if self.context.customContentLayout is None:

--- a/plone/app/blocks/testing.py
+++ b/plone/app/blocks/testing.py
@@ -9,7 +9,6 @@ from zope.configuration import xmlconfig
 
 
 class BlocksLayer(PloneSandboxLayer):
-
     defaultBases = (PLONE_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):

--- a/plone/app/blocks/tests/test_contentlayout.py
+++ b/plone/app/blocks/tests/test_contentlayout.py
@@ -22,7 +22,6 @@ else:
 
 
 class TestContentLayout(unittest.TestCase):
-
     layer = BLOCKS_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/plone/app/blocks/tests/test_layoutbehavior.py
+++ b/plone/app/blocks/tests/test_layoutbehavior.py
@@ -30,7 +30,6 @@ else:
 
 
 class TestLayoutBehavior(unittest.TestCase):
-
     layer = BLOCKS_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/plone/app/blocks/tests/test_page_sitelayout.py
+++ b/plone/app/blocks/tests/test_page_sitelayout.py
@@ -15,7 +15,6 @@ import unittest
 
 
 class TestPageSiteLayout(unittest.TestCase):
-
     layer = BLOCKS_FUNCTIONAL_TESTING
 
     def setUp(self):
@@ -240,7 +239,6 @@ class TestPageSiteLayout(unittest.TestCase):
 
 
 class TestPageSiteLayoutAcquisition(unittest.TestCase):
-
     layer = BLOCKS_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/plone/app/blocks/tests/test_resource.py
+++ b/plone/app/blocks/tests/test_resource.py
@@ -7,7 +7,6 @@ import unittest
 
 
 class TestResource(unittest.TestCase):
-
     layer = BLOCKS_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/plone/app/blocks/tests/test_sitelayout.py
+++ b/plone/app/blocks/tests/test_sitelayout.py
@@ -27,7 +27,6 @@ import unittest
 
 
 class TestSiteLayout(unittest.TestCase):
-
     layer = BLOCKS_FUNCTIONAL_TESTING
 
     def setUp(self):

--- a/plone/app/blocks/tests/test_tiles.py
+++ b/plone/app/blocks/tests/test_tiles.py
@@ -20,7 +20,6 @@ except NameError:
 
 
 class ITestTile(Interface):
-
     magicNumber = schema.Int(title="Magic number", required=False)
 
 
@@ -81,7 +80,6 @@ class TestTileBroken(Tile):
 
 
 class TestTilesLayer(PloneSandboxLayer):
-
     defaultBases = (BLOCKS_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
@@ -225,7 +223,6 @@ testLayout4 = """\
 
 
 class TestRenderTiles(unittest.TestCase):
-
     layer = BLOCKS_TILES_INTEGRATION_TESTING
 
     def testRenderTiles(self):

--- a/plone/app/blocks/tests/test_traversers.py
+++ b/plone/app/blocks/tests/test_traversers.py
@@ -4,7 +4,6 @@ import unittest
 
 
 class TestTraversers(unittest.TestCase):
-
     layer = BLOCKS_INTEGRATION_TESTING
 
     def test_site_layout_traverser_registered(self):

--- a/plone/app/blocks/tests/test_utils.py
+++ b/plone/app/blocks/tests/test_utils.py
@@ -35,7 +35,6 @@ class TestUtils(unittest.TestCase):
 
 
 class TestUtilsFunctional(unittest.TestCase):
-
     layer = BLOCKS_FUNCTIONAL_TESTING
 
     def test_resolve_resource(self):

--- a/plone/app/blocks/transform.py
+++ b/plone/app/blocks/transform.py
@@ -68,7 +68,6 @@ class ParseXML:
         return self.transformIterable([result], encoding)
 
     def transformIterable(self, result, encoding):
-
         if self.request.get("plone.app.blocks.disabled", False):
             return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -c constraints.txt
--e .[test] --install-option="--pre"
+-e .[test] --pre
 
 # WSGI: A system for configuration of WSGI web components in declarative .ini format.
 Paste


### PR DESCRIPTION
pip no longer supports the --install-options argument, but we can use --pre instead.

See: https://github.com/mxstack/mxdev/pull/30/files