### PR TITLE
Backport linkintegrity fix to 5.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,8 @@ jobs:
         # [Python version, tox env]
         - ["2.7",   "plone51-py27"]
         - ["2.7",   "plone52-py27"]
-        - ["3.7",   "plone52-py37"]
         - ["3.8",   "plone52-py38"]
-        # - ["3.7",   "plone60-py37"]
-        - ["3.8",   "plone60-py38"]
-        - ["3.9",   "plone60-py39"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - 5.x
   pull_request:
     branches:
       - master
+      - 5.x
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,9 +22,12 @@ jobs:
     runs-on: ubuntu-20.04
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      # setup-python stopped supporting Python 2.7, use https://github.com/MatteoH2O1999/setup-python
+      # This action tries to build all Python versions that actions/setup-python does not support.
+      # It caches built versions, so that after the first run, installation time is really low.
+      uses: MatteoH2O1999/setup-python@v1
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         config:
         # [Python version, tox env]

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ parts/
 var/
 src/
 /pip-selfcheck.json
+.python-version

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix for AttributeError in linkintegrity code when pasting a folder containing a page with tiles.
+  Related to `issue 97 <https://github.com/plone/plone.app.blocks/issues/97>`_.
+  [cillianderoiste]
 
 
 5.2.1 (2022-12-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 5.2.2 (unreleased)
 ------------------
 
+- No longer test on Python 3.7 or on Plone 6.0.
+  For Plone 6 you can use version 7 or higher.
+  Plone 5.1 is officially still supported, and Python 2.7 as well.
+  [maurits]
+
 - Fix for AttributeError in linkintegrity code when pasting a folder containing a page with tiles.
   Related to `issue 97 <https://github.com/plone/plone.app.blocks/issues/97>`_.
   [cillianderoiste]

--- a/base.cfg
+++ b/base.cfg
@@ -19,3 +19,6 @@ return-status-codes = False
 plone.app.blocks =
 setuptools =
 zc.buildout =
+
+[versions:python27]
+pep517 = 0.9.1

--- a/plone/app/blocks/layoutbehavior.py
+++ b/plone/app/blocks/layoutbehavior.py
@@ -31,7 +31,6 @@ from zope import schema
 from zope.annotation.interfaces import IAnnotations
 from zope.component import adapter
 from zope.component import getUtility
-from zope.component import queryUtility
 from zope.deprecation import deprecate
 from zope.interface import implementer
 from zope.interface import Interface

--- a/plone/app/blocks/linkintegrity.py
+++ b/plone/app/blocks/linkintegrity.py
@@ -60,7 +60,6 @@ class BlocksDXGeneral(DXGeneral):
             iterable, pretty_print=False, encoding='utf-8'
         )
 
-
         for tile_node in utils.bodyTileXPath(result.tree):
             tile_url = tile_node.attrib[utils.tileAttrib]
             # assume request query parameters are always useless

--- a/plone/app/blocks/linkintegrity.py
+++ b/plone/app/blocks/linkintegrity.py
@@ -40,7 +40,7 @@ class BlocksDXGeneral(DXGeneral):
         if self.context.customContentLayout is None:
             return links
 
-        if aq_parent(self.context) is None:
+        if aq_parent(self.context) is None or not hasattr(self.context, "REQUEST"):
             # context has not been added to a container yet.
             # This happens when pasting an item.
             # This easily leads to errors traversing to tiles.

--- a/plone/app/blocks/tests/context.rst
+++ b/plone/app/blocks/tests/context.rst
@@ -69,8 +69,8 @@ the default title of the portal object, ``Plone site`` will be used::
 
     >>> portal = layer['portal']
     >>> browser.open(portal.absolute_url() + '/@@page-layout')
-    >>> print(browser.headers.get("Content-Type"))
-    text/html; charset=utf-8
+    >>> print(browser.headers.get("Content-Type").split(";")[0])
+    text/html
     >>> browser.isHtml
     True
     >>> print(browser.contents)

--- a/plone/app/blocks/tests/context.rst
+++ b/plone/app/blocks/tests/context.rst
@@ -11,6 +11,7 @@ and page layouts, respectively::
     >>> class SiteLayout(BrowserView):
     ...     __name__ = 'site-layout'
     ...	    def __call__(self):
+    ...         self.request.response.setHeader("Content-Type", "text/html")
     ...         return u"""
     ... <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
     ... <html>
@@ -29,6 +30,7 @@ and page layouts, respectively::
     ... class PageLayout(BrowserView):
     ...     __name__ = 'page-layout'
     ...	    def __call__(self):
+    ...         self.request.response.setHeader("Content-Type", "text/html")
     ...         return u"""
     ... <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
     ... <html data-layout="./@@site-layout">
@@ -67,6 +69,10 @@ the default title of the portal object, ``Plone site`` will be used::
 
     >>> portal = layer['portal']
     >>> browser.open(portal.absolute_url() + '/@@page-layout')
+    >>> print(browser.headers.get("Content-Type"))
+    text/html; charset=utf-8
+    >>> browser.isHtml
+    True
     >>> print(browser.contents)
     <!DOCTYPE html...
         <title>Plone site</title>...

--- a/plone/app/blocks/tests/rendering.rst
+++ b/plone/app/blocks/tests/rendering.rst
@@ -244,6 +244,7 @@ In real life, these could be registered using the standard ``<browser:page />`` 
     ... class Page(BrowserView):
     ...     __name__ = 'test-page'
     ...     def __call__(self):
+    ...         self.request.response.setHeader("Content-Type", "text/html")
     ...         return pageHTML
 
     >>> class ITestTile(Interface):
@@ -254,6 +255,7 @@ In real life, these could be registered using the standard ``<browser:page />`` 
     ...
     ...     def __call__(self):
     ...         # fake a page template to keep things simple in the test
+    ...         self.request.response.setHeader("Content-Type", "text/html")
     ...         return """\
     ... <html>
     ...     <head>

--- a/plone/app/blocks/tests/test_linkintegrity.py
+++ b/plone/app/blocks/tests/test_linkintegrity.py
@@ -1,0 +1,150 @@
+from plone.app.blocks.testing import BLOCKS_FIXTURE
+from plone.app.linkintegrity.interfaces import IRetriever
+from plone.app.linkintegrity.parser import extractLinks
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.dexterity.fti import DexterityFTI
+from plone.registry.interfaces import IRegistry
+from plone.tiles import Tile
+from plone.uuid.interfaces import IUUID
+from Products.CMFPlone.interfaces import IEditingSchema
+from zope.component import adapter
+from zope.component import getUtility
+from zope.configuration import xmlconfig
+from zope.interface import implementer
+from zope.interface import Interface
+
+import pkg_resources
+import unittest
+
+
+try:
+    pkg_resources.get_distribution("plone.app.contenttypes")
+except pkg_resources.DistributionNotFound:
+    HAS_PLONE_APP_CONTENTTYPES = False
+else:
+    HAS_PLONE_APP_CONTENTTYPES = True
+
+
+class ITestTile(Interface):
+    """test marker"""
+
+
+class TestTile(Tile):
+    def __call__(self):
+        return (
+            "<a href=\"resolveuid/{}\">internal link</a>".format(
+                self.request.form.get('uid')
+            )
+        )
+
+
+@implementer(IRetriever)
+@adapter(TestTile)
+class TestTileRetriever:
+    def __init__(self, context):
+        self.context = context
+
+    def retrieveLinks(self):
+        content = self.context()
+        return set(extractLinks(content))
+
+
+class TestTilesLayer(PloneSandboxLayer):
+    defaultBases = (BLOCKS_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        xmlconfig.string(
+            """\
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    i18n_domain="plone.app.blocks">
+
+  <include package="plone.tiles" file="meta.zcml" />
+
+  <plone:tile
+      name="test.tile"
+      title="Test Tile"
+      add_permission="cmf.ModifyPortalContent"
+      class="plone.app.blocks.tests.test_linkintegrity.TestTile"
+      permission="zope2.View"
+      for="*"
+      />
+
+  <adapter
+      factory="plone.app.blocks.tests.test_linkintegrity.TestTileRetriever"
+      />
+
+</configure>
+""",
+            context=configurationContext,
+        )
+
+
+BLOCKS_TILES_LINKINTEGRITY_FIXTURE = TestTilesLayer()
+BLOCKS_TILES_LINKINTEGRITY_INTEGRATION_TESTING = IntegrationTesting(
+    bases=(BLOCKS_TILES_LINKINTEGRITY_FIXTURE,),
+    name="Blocks:Tiles:LinkIntegrity:Integration",
+)
+
+
+class TestLinkIntegrity(unittest.TestCase):
+    layer = BLOCKS_TILES_LINKINTEGRITY_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        self.registry = getUtility(IRegistry)
+        self.maxDiff = None
+
+        editing_settings = self.registry.forInterface(IEditingSchema, prefix="plone")
+        editing_settings.enable_link_integrity_checks = True
+
+        fti = DexterityFTI(
+            "MyDocument",
+            global_allow=True,
+            behaviors=(
+                "plone.app.dexterity.behaviors.metadata.IBasic",
+                "plone.app.blocks.layoutbehavior.ILayoutAware",
+            ),
+        )
+        self.portal.portal_types._setObject("MyDocument", fti)
+
+        setRoles(self.portal, TEST_USER_ID, ("Manager",))
+        self.portal.invokeFactory("Folder", "f1", title="Folder 1")
+        self.folder = self.portal["f1"]
+        self.folder.invokeFactory("MyDocument", "d1", title="Document 1")
+        self.doc1 = self.folder["d1"]
+        self.folder.invokeFactory("MyDocument", "d2", title="Document 2")
+        self.doc2 = self.folder["d2"]
+
+        # set customContentLayout to @@test_tile with internal Link
+        self.doc1.customContentLayout = """
+            <html><body><div data-tile="./@@test.tile?uid={}"/></body></html>
+            """.format(
+            IUUID(self.doc2)
+        )
+
+    def test_copy_paste(self):
+        # see
+        _cp = self.folder.manage_copyObjects(
+            [
+                "d1",
+            ]
+        )
+        self.folder.manage_pasteObjects(_cp)
+
+        self.assertTrue("copy_of_d1" in self.folder)
+
+        _cp = self.portal.manage_copyObjects(
+            [
+                "f1",
+            ]
+        )
+        self.portal.manage_pasteObjects(_cp)
+
+        self.assertTrue("copy_of_f1" in self.portal)
+        self.assertTrue("d1" in self.portal["copy_of_f1"])

--- a/plone/app/blocks/utils.py
+++ b/plone/app/blocks/utils.py
@@ -95,7 +95,7 @@ def resolve(url, resolved=None):
     if not resolved.strip():
         return
 
-    if isinstance(resolved, str):
+    if isinstance(resolved, six.string_types):
         resolved = resolved.encode("utf-8")
 
     try:

--- a/plone/app/blocks/utils.py
+++ b/plone/app/blocks/utils.py
@@ -95,7 +95,7 @@ def resolve(url, resolved=None):
     if not resolved.strip():
         return
 
-    if isinstance(resolved, six.string_types):
+    if isinstance(resolved, six.text_type):
         resolved = resolved.encode("utf-8")
 
     try:

--- a/requirements-5.1.x.txt
+++ b/requirements-5.1.x.txt
@@ -1,0 +1,2 @@
+-c https://dist.plone.org/release/5.1-latest/constraints.txt
+-r https://dist.plone.org/release/5.1-latest/requirements.txt

--- a/requirements-5.2.x.txt
+++ b/requirements-5.2.x.txt
@@ -1,0 +1,2 @@
+-c https://dist.plone.org/release/5.2-latest/constraints.txt
+-r https://dist.plone.org/release/5.2-latest/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/test-6.0.x.cfg
+++ b/test-6.0.x.cfg
@@ -1,4 +1,0 @@
-[buildout]
-extends =
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-6.0.x.cfg
-    base.cfg

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.18
 envlist =
     plone51-py27
-    plone52-py{27,37,38}
+    plone52-py{27,38}
 
 [testenv]
 # We do not install with pip, but with buildout:

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,8 @@ envlist =
 usedevelop = false
 skip_install = true
 deps =
-    zc.buildout
+    plone51: -rrequirements-5.1.x.txt
+    plone52: -rrequirements-5.2.x.txt
 commands_pre =
     plone51: {envbindir}/buildout -nc {toxinidir}/test-5.1.x.cfg buildout:directory={envdir} buildout:develop={toxinidir}
     plone52: {envbindir}/buildout -nc {toxinidir}/test-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir}


### PR DESCRIPTION
Backport of https://github.com/plone/plone.app.blocks/pull/107 to the 5.x branch (used on Plone 5.2).
Plus fixes to the tests and GitHub Actions.