### PR TITLE
Register richtext IJsonCompatible conditionally

### DIFF
--- a/news/124.bugfix
+++ b/news/124.bugfix
@@ -1,0 +1,5 @@
+Do not register a global ``IJsonCompatible`` adapter for ``IRichTextValue``:
+it conflicts with the converter shipped by ``plone.restapi`` >= 10 and broke
+Zope startup with a ``ConfigurationConflictError``. Tile data serialization
+still keeps the raw rich text value by applying the conversion explicitly.
+[petschki]

--- a/src/plone/app/blocks/bbb_richtext.py
+++ b/src/plone/app/blocks/bbb_richtext.py
@@ -14,7 +14,6 @@ See https://github.com/plone/plone.app.blocks/issues/124
 from plone.app.textfield.interfaces import IRichTextValue  # noqa: F401
 from plone.restapi.serializer import converters
 
-
 if hasattr(converters, "richtextvalue_converter"):
     raise ImportError(
         "plone.restapi already registers an IJsonCompatible converter "

--- a/src/plone/app/blocks/bbb_richtext.py
+++ b/src/plone/app/blocks/bbb_richtext.py
@@ -1,0 +1,22 @@
+"""Marker module for the ``installed plone.app.blocks.bbb_richtext``
+ZCML condition in ``configure.zcml``.
+
+This module is importable only when the ``IJsonCompatible`` adapter for
+``IRichTextValue`` (``utils.richtext_json_compatible``) has to be
+registered by plone.app.blocks itself: ``plone.app.textfield`` must be
+available and ``plone.restapi`` must not already ship its own converter.
+plone.restapi >= 10.0.3 registers one, so registering ours as well would
+break Zope startup with a ``ConfigurationConflictError``.
+
+See https://github.com/plone/plone.app.blocks/issues/124
+"""
+
+from plone.app.textfield.interfaces import IRichTextValue  # noqa: F401
+from plone.restapi.serializer import converters
+
+
+if hasattr(converters, "richtextvalue_converter"):
+    raise ImportError(
+        "plone.restapi already registers an IJsonCompatible converter "
+        "for IRichTextValue"
+    )

--- a/src/plone/app/blocks/configure.zcml
+++ b/src/plone/app/blocks/configure.zcml
@@ -26,7 +26,7 @@
 
   <adapter
       factory=".utils.richtext_json_compatible"
-      zcml:condition="installed plone.app.textfield"
+      zcml:condition="installed plone.app.blocks.bbb_richtext"
       />
 
   <include package="plone.app.registry" />

--- a/src/plone/app/blocks/layoutbehavior.py
+++ b/src/plone/app/blocks/layoutbehavior.py
@@ -10,6 +10,7 @@ from plone.app.blocks.interfaces import DEFAULT_SITE_LAYOUT_REGISTRY_KEY
 from plone.app.blocks.interfaces import ILayoutField
 from plone.app.blocks.utils import _get_request_cache
 from plone.app.blocks.utils import applyTilePersistent
+from plone.app.blocks.utils import HAS_RICH_TEXT_VALUE
 from plone.app.blocks.utils import resolveResource
 from plone.app.blocks.utils import schema_compatible
 from plone.autoform.directives import omitted
@@ -38,6 +39,10 @@ from zope.interface import provider
 
 import json
 import logging
+
+if HAS_RICH_TEXT_VALUE:
+    from plone.app.blocks.utils import richtext_json_compatible
+    from plone.app.textfield.interfaces import IRichTextValue
 
 logger = logging.getLogger("plone.app.blocks")
 
@@ -426,6 +431,18 @@ class LayoutAwareTileDataStorage:
 
     def __setitem__(self, key, value):
         key, schema_ = self.resolve(key)
+        # RichTextValues are converted explicitly to keep their raw source;
+        # plone.restapi's registered IJsonCompatible converter would render
+        # them and lose the roundtrip data (see utils.richtext_json_compatible).
+        if HAS_RICH_TEXT_VALUE:
+            value = {
+                name: (
+                    richtext_json_compatible(val)
+                    if IRichTextValue.providedBy(val)
+                    else val
+                )
+                for name, val in value.items()
+            }
         data = json_compatible(value)
 
         # Store primary field as tile tag content

--- a/src/plone/app/blocks/utils.py
+++ b/src/plone/app/blocks/utils.py
@@ -50,6 +50,17 @@ if HAS_RICH_TEXT_VALUE:
     @adapter(IRichTextValue)
     @implementer(IJsonCompatible)
     def richtext_json_compatible(value):
+        """Convert a RichTextValue to a json-compatible dict, keeping the
+        raw value and output mime type intact for a lossless roundtrip.
+
+        Only registered as a global adapter when plone.restapi does not
+        ship its own IJsonCompatible converter for IRichTextValue (added
+        in plone.restapi 10.0.3) — a second registration would conflict.
+        See bbb_richtext.py for the ZCML condition. Tile data
+        serialization applies this conversion explicitly either way, as
+        the plone.restapi converter renders the value instead of keeping
+        the raw source.
+        """
         return {
             "data": value.raw,
             "content-type": value.mimeType,


### PR DESCRIPTION
plone.restapi >= 10.0.3 ships its own IJsonCompatible converter for IRichTextValue, so the unconditional registration in plone.app.blocks broke Zope startup with a ConfigurationConflictError (fixes #124).

Keep the adapter for older plone.restapi versions via a ZCML condition on the new bbb_richtext marker module, which is only importable when plone.restapi does not provide the converter. Tile data serialization applies the conversion explicitly in both cases, since the restapi converter renders the value and would lose the raw source in the tile data roundtrip.

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #124 

